### PR TITLE
Use inline const for EGAVDeviceID declaration

### DIFF
--- a/Library/ElgatoUVCDevice.h
+++ b/Library/ElgatoUVCDevice.h
@@ -37,8 +37,8 @@ SOFTWARE.
 #endif
 
 
-const EGAVDeviceID deviceIDHD60SPlus (EGAVBusType::USB, 0x0FD9, 0x06A); //!< HD60 S+
-const EGAVDeviceID deviceIDHD60X     (EGAVBusType::USB, 0x0FD9, 0x082); //!< HD60 X
+inline const EGAVDeviceID deviceIDHD60SPlus (EGAVBusType::USB, 0x0FD9, 0x06A); //!< HD60 S+
+inline const EGAVDeviceID deviceIDHD60X     (EGAVBusType::USB, 0x0FD9, 0x082); //!< HD60 X
 
 inline bool IsNewDeviceType(const EGAVDeviceID& inDeviceID) { return (inDeviceID == deviceIDHD60X); }
 


### PR DESCRIPTION
Avoids instantiating a separate EGAVDeviceID for every compilation unit that uses the header. Detected by PVS Studio static analysis.

Reference: https://www.learncpp.com/cpp-tutorial/sharing-global-constants-across-multiple-files-using-inline-variables/#:~:text=Global%20constants%20as%20inline%20variables