### PR TITLE
Use NOMINMAX always

### DIFF
--- a/Library/EGAVResult.h
+++ b/Library/EGAVResult.h
@@ -42,6 +42,7 @@ SOFTWARE.
 	// FMB NOTE: For some strange reason <WinSock2.h> must be before <Windows.h>. 
 	// This is only necessary because contents of <WinSock2.h> are required in other code files.
 	// However, if <WinSock2.h> is include somewhere it must be guaranteded that <Windows.h> was never include before.
+	#define NOMINMAX
 	#include <WinSock2.h>	// for sockaddr_in
 	#include <Windows.h>
 #endif


### PR DESCRIPTION
Ensure that Windows.h doesn't define min/max macros.

This probably should have been done in #6. I considered adding this to the project's CMake instead, but some consumers (such as obs-studio) do not consume this as a CMake Target or library, but pull in the source files instead. To reliably set this in this project's CMake for consumers, you would need to expose a CMake target that could be pulled in as a dependency, either as a static library or as an interface library. I do not have the bandwidth to contribute such a change, so I opted for this change instead.