### PR TITLE
Guard NOMINMAX usage

### DIFF
--- a/Library/EGAVResult.h
+++ b/Library/EGAVResult.h
@@ -42,7 +42,9 @@ SOFTWARE.
 	// FMB NOTE: For some strange reason <WinSock2.h> must be before <Windows.h>. 
 	// This is only necessary because contents of <WinSock2.h> are required in other code files.
 	// However, if <WinSock2.h> is include somewhere it must be guaranteded that <Windows.h> was never include before.
+	#ifndef NOMINMAX
 	#define NOMINMAX
+	#endif
 	#include <WinSock2.h>	// for sockaddr_in
 	#include <Windows.h>
 #endif


### PR DESCRIPTION
If a consumer already specifies NOMINMAX, unconditionally defining it here can result in redefinition warnings (C4005) or errors if warnings are treated as errors. To avoid this, let's guard the definition.