### PR TITLE
Use platform preprocessor checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,9 +56,3 @@ add_executable (EGAVHIDSample
 
 target_include_directories(EGAVHIDSample PRIVATE ${FRAMEWORK_FOLDER})
 target_compile_definitions(EGAVHIDSample PUBLIC EGAV_API)
-
-if(WIN32)
-    target_compile_definitions(EGAVHIDSample PUBLIC _UP_WINDOWS=1)
-elseif(APPLE)
-    target_compile_definitions(EGAVHIDSample PUBLIC _UP_MAC=1)
-endif()

--- a/Library/EGAVResult.cpp
+++ b/Library/EGAVResult.cpp
@@ -31,7 +31,7 @@ SOFTWARE.
 //==============================================================================
 
 #include "EGAVResult.h"
-#if _UP_WINDOWS
+#if defined(_WIN32)
 #include <winerror.h> // for HRESULT
 #endif
 
@@ -51,7 +51,7 @@ EGAVResult::EGAVResult(EGAVResultCustomType inCustomResultType, int64_t inCustom
 	mCustomResultCode = inCustomResultCode;
 }
 
-#if _UP_WINDOWS
+#if defined(_WIN32)
 void EGAVResult::InitWithHresult(HRESULT hr)
 {
 	mResultCode       = ErrCustom;
@@ -77,10 +77,10 @@ bool EGAVResult::Succeeded() const
 	{
 		switch (mCustomResultType)
 		{
-#if _UP_WINDOWS
+#if defined(_WIN32)
 		case EGAVResultCustomType::Hresult:		return SUCCEEDED(mCustomResultCode);
 		case EGAVResultCustomType::WinError:	return (mCustomResultCode == ERROR_SUCCESS) ? true : false;
-#elif _UP_MAC
+#elif defined(__APPLE__)
 		case EGAVResultCustomType::Mac:			return (mCustomResultCode == 0) ? true : false;
 #endif
 		case EGAVResultCustomType::MainConcept:

--- a/Library/EGAVResult.h
+++ b/Library/EGAVResult.h
@@ -38,7 +38,7 @@ SOFTWARE.
 //------------------------------------------------------------------------------
 
 #include <string>
-#if _UP_WINDOWS 
+#if defined(_WIN32)
 	// FMB NOTE: For some strange reason <WinSock2.h> must be before <Windows.h>. 
 	// This is only necessary because contents of <WinSock2.h> are required in other code files.
 	// However, if <WinSock2.h> is include somewhere it must be guaranteded that <Windows.h> was never include before.
@@ -50,7 +50,7 @@ SOFTWARE.
 //#include "EGAVFeatures.h" // for EGAV_API
 
 
-#define EVH_AVOID_UNNEEDED_COPY_CONSTRUCTORS 			(!_UP_WINDOWS)	//!< 0 - explicit copy constructors: required for .NET frontends connected via SWIG e.g. 4KCU and EVH Test App
+#define EVH_AVOID_UNNEEDED_COPY_CONSTRUCTORS 			(!defined(_WIN32))	//!< 0 - explicit copy constructors: required for .NET frontends connected via SWIG e.g. 4KCU and EVH Test App
 																		//!< 1 - to avoid "warning: definition of implicit copy constructor for different classes e.g.
 																		//! 'EGAVAudioSampleType' is deprecated because it has a user-declared copy assignment operator [-Wdeprecated-copy]"
 
@@ -141,7 +141,7 @@ public:
 	//------------------------------------------------------------------------------
 	// Initialization
 	//------------------------------------------------------------------------------
-#if _UP_WINDOWS
+#if defined(_WIN32)
 
 	//! Init with HRESULT (EGAVResultCustomType::Hresult)
 	void InitWithHresult(HRESULT hr);


### PR DESCRIPTION
Instead of using CMake to check the platform and then set a target compile definition to indicate the platform, just directly check the platform by checking known platform defines.

This removes the need for consumers who do not use this repo's CMakeLists.txt to set `_UP_WINDOWS` or `_UP_MAC`.

If this was done for a particular reason, feel free to close this pull request.

I don't know how `EVH_AVOID_UNNEEDED_COPY_CONSTRUCTORS` is used because it isn't used anywhere in this repo, so you'll have to check that that change works for you.